### PR TITLE
Removes friendlyName from payload

### DIFF
--- a/src/data.json
+++ b/src/data.json
@@ -30,7 +30,6 @@
                 "type": "primary"
             }
         ],
-        "friendlyName": "Welcome Component",
         "url": "http://localhost:3375/components/welcome/welcome.html"
     },
     {
@@ -70,8 +69,7 @@
                 "url": "https://i.imgur.com/REWQ5k6.png",
                 "type": "primary"
             }
-        ],
-        "friendlyName": "Notepad"
+        ]
     },
     {
         "name": "Process Monitor",
@@ -151,7 +149,6 @@
                 "url": "https://i.imgur.com/aTxEQep.png",
                 "type": "primary"
             }
-        ],
-        "friendlyName": "Sample"
+        ]
     }
 ]


### PR DESCRIPTION
friendlyName is not a FDC3 property. In order to avoid confusion for users using this as an example of App D, this PR removed that property.

Tested all 4 endpoints to make sure I didn't heck up anything in the JSON.