### PR TITLE
22923 aac load components

### DIFF
--- a/src/data.json
+++ b/src/data.json
@@ -116,7 +116,7 @@
         "entitled": true,
         "description": "This is an example app with no particular purpose.",
         "appId": "nmua",
-        "manifest": "http://localhost:3030/v1/component",
+        "manifest": "{\"window\":{\"url\":\"https://www.chartiq.com/tutorials/?slug=finsemble\",\"height\":800,\"width\":1000},\"component\":{\"spawnOnStartup\":false},\"foreign\":{\"services\":{\"workspaceService\":{\"persistURL\":true}},\"components\":{\"App Launcher\":{\"launchableByUser\":false},\"Window Manager\":{\"showLinker\":false,\"FSBLHeader\":true,\"persistWindowState\":true,\"title\":\"Finsemble Getting Started Tutorial\"}}}}",
         "manifestType": "Finsemble",
         "title": "Sample Component",
         "tooltip": "Tooltip",

--- a/src/data.json
+++ b/src/data.json
@@ -116,7 +116,7 @@
         "entitled": true,
         "description": "This is an example app with no particular purpose.",
         "appId": "nmua",
-        "manifest": "{\"window\":{\"url\":\"https://www.chartiq.com/tutorials/?slug=finsemble\",\"height\":800,\"width\":1000},\"component\":{\"spawnOnStartup\":false},\"foreign\":{\"services\":{\"workspaceService\":{\"persistURL\":true}},\"components\":{\"App Launcher\":{\"launchableByUser\":false},\"Window Manager\":{\"showLinker\":false,\"FSBLHeader\":true,\"persistWindowState\":true,\"title\":\"Finsemble Getting Started Tutorial\"}}}}",
+        "manifest": "{\"window\":{\"url\":\"https://www.chartiq.com/tutorials/?slug=finsemble\",\"height\":800,\"width\":1000},\"component\":{\"spawnOnStartup\":false},\"foreign\":{\"services\":{\"workspaceService\":{\"persistURL\":true}},\"components\":{\"App Launcher\":{\"launchableByUser\":true},\"Window Manager\":{\"showLinker\":false,\"FSBLHeader\":true,\"persistWindowState\":true,\"title\":\"Finsemble Getting Started Tutorial\"}}}}",
         "manifestType": "Finsemble",
         "title": "Sample Component",
         "tooltip": "Tooltip",


### PR DESCRIPTION
fix: #id [22923]

[Kanban link](https://chartiq.kanbanize.com/ctrl_board/18/cards/22923/details)

**Moved load of AAC components to Startup**
Decision was node to not support URL as manifest right now. Sample Component manifest URL was changed to a string.

**Description of testing**

1. Run Finsemble
1. Add a Sample Component to a Workspace via AAC.
1. Reload Finsemble and verify Sample Component
1. Verify that Sample Component is available via Toolbar Search.
1. No additional Central Logger Errors or Warnings that are not required were introduced by this PR